### PR TITLE
記事とタグのアソシエーションを実装

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -2,4 +2,7 @@ class Article < ApplicationRecord
   validates :title, presence:true
   validates :content, presence:true
   belongs_to :user
+
+  has_many :tags_articles, dependent: :destroy  #親であるarticleが削除されたとき、それと紐づくtags_articlesも削除できるように追加
+  has_many :tags, through: :tags_articles
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,3 +1,6 @@
 class Tag < ApplicationRecord
   validates :name, presence:true
+
+  has_many :tags_articles, dependent: :destroy #親であるarticleが削除されたとき、それと紐づくtags_articlesも削除できるように追加
+  has_many :articles, through: :tags_articles
 end

--- a/app/models/tags_article.rb
+++ b/app/models/tags_article.rb
@@ -1,0 +1,4 @@
+class TagsArticle < ApplicationRecord
+  belongs_to :tag
+  belongs_to :article
+end

--- a/db/migrate/20220928015321_create_tags_articles.rb
+++ b/db/migrate/20220928015321_create_tags_articles.rb
@@ -1,0 +1,10 @@
+class CreateTagsArticles < ActiveRecord::Migration[6.0]
+  def change
+    create_table :tags_articles do |t|
+      t.references :tag, null: false, foreign_key: true
+      t.references :article, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_28_003941) do
+ActiveRecord::Schema.define(version: 2022_09_28_015321) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,15 @@ ActiveRecord::Schema.define(version: 2022_09_28_003941) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "tags_articles", force: :cascade do |t|
+    t.bigint "tag_id", null: false
+    t.bigint "article_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["article_id"], name: "index_tags_articles_on_article_id"
+    t.index ["tag_id"], name: "index_tags_articles_on_tag_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -43,4 +52,6 @@ ActiveRecord::Schema.define(version: 2022_09_28_003941) do
   end
 
   add_foreign_key "articles", "users"
+  add_foreign_key "tags_articles", "articles"
+  add_foreign_key "tags_articles", "tags"
 end


### PR DESCRIPTION
##概要

- 設計を基に記事とユーザーのアソシエーションを実装しました。
- articlesテーブルとtagsテーブルの関係から、中間テーブル（tags_articles）テーブルを作成しました。