### PR TITLE
記事とタグを紐づけての作成と表示を実装

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -8,9 +8,9 @@ class ArticlesController < ApplicationController
     # @articles = Article.where("title LIKE ?", "%#{params[:title]}%")
 
     if params[:title]
-      @articles = Article.where("title LIKE ?", "%#{params[:title]}%").page(params[:page])
+      @articles = Article.preload(:tags).where("title LIKE ?", "%#{params[:title]}%").page(params[:page])
     else
-      @articles = Article.all.page(params[:page])
+      @articles = Article.preload(:tags).all.page(params[:page])
     end
   end
 
@@ -36,6 +36,7 @@ class ArticlesController < ApplicationController
 # binding.pry
     respond_to do |format|
       if @article.save
+        # binding.pry
         format.html { redirect_to article_url(@article), notice: " 新たな記事を作成しました " }
       else
         format.html { render :new, status: :unprocessable_entity }
@@ -71,6 +72,7 @@ class ArticlesController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def article_params
-      params.require(:article).permit(:title, :content).merge(user_id: current_user.id)
+      binding.pry
+      params.require(:article).permit(:title, :content, tag_ids: []).merge(user_id: current_user.id)
     end
 end

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -5,9 +5,9 @@ class MypagesController < ApplicationController
     @articles = current_user.articles.all.page(params[:page])
 
     if params[:title]
-      @articles = current_user.articles.where("title LIKE ?", "%#{params[:title]}%").page(params[:page])
+      @articles = current_user.articles.preload(:tags).where("title LIKE ?", "%#{params[:title]}%").page(params[:page])
     else
-      @articles = current_user.articles.all.page(params[:page])
+      @articles = current_user.articles.preload(:tags).all.page(params[:page])
     end
 
   end

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -12,6 +12,10 @@
   <% end %>
 
   <div class="mb-3">
+    <%= form.collection_check_boxes :tag_ids, Tag.all, :id, :name %>
+  </div>
+
+  <div class="mb-3">
     <%= form.label :title, class: "form-label" %>
     <%= form.text_field :title, class: "form-control" %>
   </div>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -15,7 +15,12 @@
   <tbody>
     <% @articles.each do |article| %>
       <tr>
-        <td><%= article.title %></td>
+        <td>
+          <%= article.title %>
+          <% article.tags.each do |tag| %>
+            <span class="badge rounded-pill bg-primary"><%= tag.name %></span>
+          <% end %>
+        </td>
         <td><%= article.content %></td>
         <td>
           <%= link_to '詳細', article, class: "btn btn-success" %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -5,6 +5,9 @@
 <div class="card">
   <div class="card-header">
     <%= @article.title %>
+      <% @article.tags.each do |tag| %>
+        <span class="badge rounded-pill bg-primary"><%= tag.name %></span>
+      <% end %>
   </div>
   <div class="card-body">
     <%= @article.content %>

--- a/app/views/mypages/index.html.erb
+++ b/app/views/mypages/index.html.erb
@@ -14,7 +14,12 @@
   <tbody>
     <% @articles.each do |article| %>
       <tr>
-        <td><%= article.title %></td>
+          <td>
+            <%= article.title %>
+            <% article.tags.each do |tag| %>
+              <span class="badge rounded-pill bg-primary"><%= tag.name %></span>
+            <% end %>
+          </td>
         <td><%= article.content %></td>
         <td><%= link_to '詳細', article, class: "btn btn-success" %></td>
         <td><%= link_to '編集', edit_article_path(article), class: "btn btn-success" %></td>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,34 +6,13 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-# 3.times do |n|
-#   User.create!(
-#     email: "user00#{n + 1}@test.com",
-#     password: "test1234"
-#   )
-# end
 
-# user = User.find_by(id: 1)
-# 50.times do |n|
-#   user.articles.create!(
-#   title: "No.#{n + 1}: user00#{user.id}の記事",
-#   content: "No.#{n + 1}: user00#{user.id}の記事の本文",
-#   )
-# end
-# user = User.find_by(id: 2)
-# 50.times do |n|
-#   user.articles.create!(
-#   title: "No.#{n + 1}: user00#{user.id}の記事",
-#   content: "No.#{n + 1}: user00#{user.id}の記事の本文",
-#   )
-# end
-# user = User.find_by(id: 3)
-# 50.times do |n|
-#   user.articles.create!(
-#   title: "No.#{n + 1}: user00#{user.id}の記事",
-#   content: "No.#{n + 1}: user00#{user.id}の記事の本文",
-#   )
-# end
+
+items = ["学習", "運動", "就活"]
+
+items.each do |item|
+  Tag.create!(name: "#{item}")
+end
 
 
 3.times do |n|
@@ -44,18 +23,13 @@
 
 
     50.times do |n|
-      user.articles.create!(
+      articles = user.articles.create!(
 
       title: "No.#{n + 1}: user00#{user.id}の記事",
       content: "No.#{n + 1}: user00#{user.id}の記事の本文",
       )
+      # binding.pry
+      articles.tag_ids = Tag.all.pluck(:id)
+
     end
 end
-
-# 50.times do |n|
-#   user.articles.create!(
-
-#   title: "No.#{n + 1}: user00#{user.id}の記事",
-#   content: "No.#{n + 1}: user00#{user.id}の記事の本文",
-#   )
-# end


### PR DESCRIPTION
##概要

- 記事の作成、編集画面から、タグ付出来るようにしました。
- seedファイルを編集しテストデータ実行時、全データに全タグが付与されるように編集しました。
- preload(:tags)を用いて、N＋1問題を改善しました。